### PR TITLE
Added 'with_self' option which gives access to the controller object itself

### DIFF
--- a/lib/MojoX/JSON/RPC/Dispatcher.pm
+++ b/lib/MojoX/JSON/RPC/Dispatcher.pm
@@ -176,6 +176,8 @@ METHOD:
                             && $rpc->{with_svc_obj} ? $service : (),
                         exists $rpc->{with_mojo_tx}
                             && $rpc->{with_mojo_tx} ? $self->tx : (),
+                        exists $rpc->{with_self}
+                            && $rpc->{with_self} ? $self : (),
                         defined $m->params
                         ? ref $m->params eq 'ARRAY'
                                 ? @{ $m->params }

--- a/lib/MojoX/JSON/RPC/Service.pm
+++ b/lib/MojoX/JSON/RPC/Service.pm
@@ -61,7 +61,7 @@ sub register {
 
     my %obj = ( method => $sub );
 OPTION:
-    foreach my $opt ( 'with_mojo_tx', 'with_svc_obj' ) {
+    foreach my $opt ( 'with_mojo_tx', 'with_svc_obj', 'with_self' ) {
         if ( !exists $options->{$opt} ) {
             next OPTION;
         }


### PR DESCRIPTION
Hi Henry,

I added 'with_self' option (similar to 'with_svc_obj' and 'with_mojo_tx') that provides access to the controller object itself (otherwise I couldn't find a way to get the controller). This is needed to operate with session data, stashes and other methods available only in the controller, from within RPC calls.
