### PR TITLE
is_debug is deprecated and removed from Mojo::Log

### DIFF
--- a/lib/MojoX/JSON/RPC/Client.pm
+++ b/lib/MojoX/JSON/RPC/Client.pm
@@ -103,7 +103,7 @@ sub _process_result {
 
     my $tx_res = $tx->res;
     my $log = $self->ua->server->app->log if $self->ua->server->app;
-    if ( $log && $log->is_debug ) {
+    if ( $log && $log->is_level('debug') ) {
         $log->debug( 'TX BODY: [' . $tx_res->body . ']' );
     }
 

--- a/lib/MojoX/JSON/RPC/Dispatcher.pm
+++ b/lib/MojoX/JSON/RPC/Dispatcher.pm
@@ -35,7 +35,7 @@ sub _acquire_methods {
     my $request;
 
     if ( $method eq 'POST' ) {
-        if ( $log->is_debug ) {
+        if ( $log->is_level('debug') ) {
             $log->debug( 'REQUEST: BODY> ' . $req->body );
         }
         


### PR DESCRIPTION
Was deprected in Mojo 6.47 and removed from Mojo 6.62 released
2016-05-14.