### PR TITLE
remove call to PODRenderer plugin which is never used

### DIFF
--- a/t/exception.t
+++ b/t/exception.t
@@ -17,9 +17,6 @@ use Mojolicious::Lite;
 
 use MojoX::JSON::RPC::Service;
 
-# Documentation browser under "/perldoc" (this plugin requires Perl 5.10)
-plugin 'PODRenderer';
-
 plugin 'json_rpc_dispatcher' => {
     services => {
         '/jsonrpc' => MojoX::JSON::RPC::Service->new->register(


### PR DESCRIPTION
t/exception.t calls the PODRenderer plugin but does not actually contain any pod.

Given that PODRenderer was deprecated in recent versions of Mojolicious, I suggest removing the call to the plugin.